### PR TITLE
"resource" is not a valid typehint in supported by PHP

### DIFF
--- a/src/PoFile.php
+++ b/src/PoFile.php
@@ -343,7 +343,7 @@ class PoFile
      *
      * @throws FileNotReadableException
      */
-    public function readPoFile(string $file, ?resource $context = null): void
+    public function readPoFile(string $file, $context = null): void
     {
         $oldEr = error_reporting(E_ALL ^ E_WARNING);
         $source = file_get_contents($file, false, $context);


### PR DESCRIPTION
Hi,
when trying your library on PHP 8 I noticed a new warning that exposed an older issue.

The `resource` typehint does not resolve to a builtin type but instead translates to the non-existing `\Geekwright\Po\resource` class.

This never worked but I also never needed to pass a resource to the readPoFile function and so it never triggered any errors.

PHP 8 now warns about this with the following message:

```
Warning: "resource" is not a supported builtin type and will be interpreted as a class name. Write "\Geekwright\Po\resource" or import the class with "use" to suppress this warning in [...]/vendor/geekwright/po/src/PoFile.php on line 346
```

The resource typehint in the phpdoc should still be fine.

Thanks!